### PR TITLE
Updated Composer type to "ezplatform-bundle"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "inviqa/ez-text-enhancer-bundle",
     "description": "Provides twig helpers to render eZ RichTexts.",
     "license": "Private",
-    "type": "project",
+    "type": "ezplatform-bundle",
     "repositories": [
         { "type": "composer", "url": "https://updates.ez.no/bul" }
     ],


### PR DESCRIPTION
Change to Composer package metadata. Changed type from `project` to `ezplatform-bundle` to boost findability in services like https://ezplatform.com/Bundles